### PR TITLE
Fix Social Links to Use Actual Profile URLs

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -55,7 +55,7 @@ export default function Home() {
               {/* Social Links */}
               <div className="flex items-center gap-4">
                 <a
-                  href="https://linkedin.com"
+                  href="https://www.linkedin.com/in/aashimaahuja"
                   target="_blank"
                   rel="noopener noreferrer"
                   className="p-2 rounded-full text-[rgb(var(--color-text-secondary))] hover:text-primary transition-colors"
@@ -70,7 +70,7 @@ export default function Home() {
                   </svg>
                 </a>
                 <a
-                  href="https://twitter.com"
+                  href="https://x.com/aashimaahuja22"
                   target="_blank"
                   rel="noopener noreferrer"
                   className="p-2 rounded-full text-[rgb(var(--color-text-secondary))] hover:text-primary transition-colors"
@@ -85,7 +85,7 @@ export default function Home() {
                   </svg>
                 </a>
                 <a
-                  href="https://github.com"
+                  href="https://github.com/aashimaahuja"
                   target="_blank"
                   rel="noopener noreferrer"
                   className="p-2 rounded-full text-[rgb(var(--color-text-secondary))] hover:text-primary transition-colors"


### PR DESCRIPTION
#1 Fix: Social Links Point to Generic URLs

### Description:
This PR fixes the social media links in the portfolio to point to Aashima Ahuja's actual profiles instead of generic homepage URLs.

### Changes Made:
- Updated LinkedIn href from https://linkedin.com to actual profile URL

- Updated Twitter/X href from https://twitter.com to actual profile URL

- Updated GitHub href from https://github.com to actual profile URL


